### PR TITLE
A small fix in the ARC docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ ARChetype CRFs are an important subset of our library of Templates. Templates ar
 
 ## ARC Version 1.5.0
 
-ARC Version 1.5.0 contains a comprehensive library of harmonised questions designed for use in **Case Report Forms (CRFs)** supporting outbreak responses and clinical surveillance across multiple infectious diseases and populations.
+The **latest ARC Version 1.5.0** contains a comprehensive library of harmonised questions designed for use in **Case Report Forms (CRFs)** supporting outbreak responses and clinical surveillance across multiple infectious diseases and populations.
 
 The ARC data model supports outbreak responses for
 
@@ -97,7 +97,7 @@ The ARC data model supports outbreak responses for
 - **Acute Respiratory Infection (ARI)**
 - **Viral Haemorrhagic Fever (VHF)**
 - **Encephalitis**
-- **Arbobvirus**
+- **Arbovirus**
 
 and includes enhanced coverage for **pregnant and paediatric populations** through both disease-specific and population-agnostic modules.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ github_repo = f"{github_url}/ISARICResearch/ARC"
 github_version = "main"
 # pypi_project = ''
 project = 'ARC'
-release = "v1.4.0"
+release = "v1.5.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
- use the correct latest version `v1.5.0` in the latest release version page