### PR TITLE
Add citation information

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,129 +5,168 @@ message: A comprehensive machine-readable document that contains a library of
          outbreaks. 
 type: database
 authors:
-  - family-names: Garcia-Gallo
-    given-names: Esteban
-    email: esteban.garcia@ndm.ox.ac.uk
-    orcid: 0000-0002-8030-9985
+  - family-names: Bourner
+    given-names: Josephine
+
+  - family-names: Carson
+    given-names: Gail
+    email: gail.carson@ndm.ox.ac.uk
+
+  - family-names: Chang
+    given-names: Aileen
+    email: chang@email.gwu.edu
+
+  - family-names: Chernyavskaya
+    given-names: Anastasiia
+
+  - family-names: Cummings
+    given-names: Matthew
+    email: mjc2244@cumc.columbia.edu
+
+  - family-names: Davtian
+    given-names: Lilit
+
+  - family-names: Darji
+    given-names: Dhruv
+    email: dhruv.darji@gtc.ox.ac.uk
+
+  - family-names: Demidova
+    given-names: Anastasiia
+    email: anastasiia.demidova@kcl.ac.uk
+
+  - family-names: Diaz
+    given-names: Janet
+    email: diazj@who.int
+
+  - family-names: Dunning
+    given-names: Jake
+    email: jake.dunning@ndm.ox.ac.uk
+
   - family-names: Duque-Vallejo
     given-names: Sara
     email: sara.duquevallejo@ndm.ox.ac.uk
     orcid: 0000-0002-6616-8354
-  - family-names: Darji
-    given-names: Dhruv
-    email: dhruv.darji@gtc.ox.ac.uk
-  - family-names: Murthy
-    given-names: Sandeep
-    email: sandeep.murthy@ndm.ox.ac.uk
-    orcid: 0009-0006-8277-9389
+
   - family-names: Edinburgh
     given-names: Tom
-  - family-names: Lunn
-    given-names: Miles
-  - family-names: Kelly
-    given-names: Sadie
-    email: sadie.kelly@ndm.ox.ac.uk
-  - family-names: Bourner
-    given-names: Josephine
-  - family-names: Chang
-    given-names: Aileen
-    email: chang@email.gwu.edu
-  - family-names: Chernyavskaya
-    given-names: Anastasiia
-  - family-names: Carson
-    given-names: Gail
-    email: gail.carson@ndm.ox.ac.uk
-  - family-names: Cummings
-    given-names: Matthew
-    email: mjc2244@cumc.columbia.edu
-  - family-names: Davtian
-    given-names: Lilit
-  - family-names: de Oliveira
-    given-names: Viviane S B
-  - family-names: Diaz
-    given-names: Janet
-    email: diazj@who.int
-  - family-names: Dunning
-    given-names: Jake
-    email: jake.dunning@ndm.ox.ac.uk
+
+  - family-names: Garcia-Gallo
+    given-names: Esteban
+    email: esteban.garcia@ndm.ox.ac.uk
+    orcid: 0000-0002-8030-9985
+
   - family-names: Hashmi
     given-names: Madiha
     email: madiha.hashmi@zu.edu.pk
+
   - family-names: Hassan
     given-names: Zakiul
     email: zakiul.hassan@ndm.ox.ac.uk
+
   - family-names: Ho
     given-names: Antonia
     email: antonia.ho@glasgow.ac.uk
+
   - family-names: Horby
     given-names: Peter
     email: peter.horby@ndm.ox.ac.uk
+
   - family-names: Jackson
     given-names: Charlotte
     email: c.r.jackson@ucl.ac.uk
+
   - family-names: Judd
     given-names: Ali
     email: a.judd@ucl.ac.uk
+
+  - family-names: Kelly
+    given-names: Sadie
+    email: sadie.kelly@ndm.ox.ac.uk
+
   - family-names: Kiseleva
     given-names: Anastasia
-  - family-names: Le Prevost
-    given-names: Marthe
-    email: m.leprevost@ucl.ac.uk
+
   - family-names: Lim
     given-names: Wei Shen
     email: WeiShen.Lim@nuh.nhs.uk
+
+  - family-names: Lunn
+    given-names: Miles
+
   - family-names: Mello
     given-names: Claudia
     email: claudia.mello@emilioribas.sp.gov.br
-  - family-names: Murthy
-    given-names: Srinivas
-    email: srinivas.murthy@cw.bc.ca
-  - family-names: Olliaro
-    given-names: Piero
-    email: piero.olliaro@ndm.ox.ac.uk
-  - family-names: Reyes
-    given-names: Luis Felipe
-    email: luis.reyes@ndm.ox.ac.uk
-  - family-names: Rojek
-    given-names: Amanda
-    email: amanda.rojek@ndm.ox.ac.uk
-  - family-names: Rylance
-    given-names: Jamie
-    email: rylancej@who.int
-  - family-names: Sauer
-    given-names: Lauren
-    email: lsauer@unmc.edu
-  - family-names: Semple
-    given-names: Calum
-    email: M.G.Semple@liverpool.ac.uk
-  - family-names: Sconza
-    given-names: Rebecca
-    email: r.sconza@ucl.ac.uk
-  - family-names: Sharin
-    given-names: Lubaba
-  - family-names: Siddiqui
-    given-names: Ayesha
-    email: ayesha.siddiqui@ndm.ox.ac.uk
-  - family-names: Uyeki
-    given-names: Tim
-    email: tmu0@cdc.gov
-  - family-names: Watson
-    given-names: Hugh
-  - family-names: Wu
-    given-names: Jan
-  - family-names: Pesonel
-    given-names: Elise
-    email: elise.pesonel@ndm.ox.ac.uk
-  - family-names: Munblit
-    given-names: Daniel
-    email: daniel.munblit@kcl.ac.uk
-  - family-names: Demidova
-    given-names: Anastasiia
-    email: anastasiia.demidova@kcl.ac.uk
+
   - family-names: Merson
     given-names: Laura
     email: laura.merson@ndm.ox.ac.uk
     orcid: 0000-0002-4168-1960
+
+  - family-names: Munblit
+    given-names: Daniel
+    email: daniel.munblit@kcl.ac.uk
+
+  - family-names: Murthy
+    given-names: Srinivas
+    email: srinivas.murthy@cw.bc.ca
+
+  - family-names: de Oliveira
+    given-names: Viviane S B
+
+  - family-names: Olliaro
+    given-names: Piero
+    email: piero.olliaro@ndm.ox.ac.uk
+
+  - family-names: Pesonel
+    given-names: Elise
+    email: elise.pesonel@ndm.ox.ac.uk
+
+  - family-names: Le Prevost
+    given-names: Marthe
+    email: m.leprevost@ucl.ac.uk
+
+  - family-names: Reyes
+    given-names: Luis Felipe
+    email: luis.reyes@ndm.ox.ac.uk
+
+  - family-names: Rojek
+    given-names: Amanda
+    email: amanda.rojek@ndm.ox.ac.uk
+
+  - family-names: Rylance
+    given-names: Jamie
+    email: rylancej@who.int
+
+  - family-names: Sauer
+    given-names: Lauren
+    email: lsauer@unmc.edu
+
+  - family-names: Sconza
+    given-names: Rebecca
+    email: r.sconza@ucl.ac.uk
+
+  - family-names: Semple
+    given-names: Calum
+    email: M.G.Semple@liverpool.ac.uk
+
+  - family-names: Sharin
+    given-names: Lubaba
+
+  - family-names: Siddiqui
+    given-names: Ayesha
+    email: ayesha.siddiqui@ndm.ox.ac.uk
+    orcid: 0000-0003-1555-720X
+
+  - family-names: Uyeki
+    given-names: Tim
+    email: tmu0@cdc.gov
+
+  - family-names: Watson
+    given-names: Hugh
+
+  - family-names: Wu
+    given-names: Jan
+
 repository-code: 'https://github.com/ISARICResearch/ARC'
 url: 'https://github.com/ISARICResearch/ARC'
 abstract: A comprehensive machine-readable document that contains a library of 
@@ -147,5 +186,8 @@ keywords:
     - crf
     - data capture
 license: MIT
-version: 1.4.0
+version: 1.5.0
 date-released: 2026-06-15
+  - description: ARC Release v1.5.0
+    type: doi
+    value: "/10.5281/zenodo.14113727"

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ ARC is **published** on [GitHub](https://github.com/ISARICResearch/ARC/releases)
 
 ARC can be **cited** as follows:
 
-> Bourner J, Carson G, Chang A, Chernyavskaya A, Cummings M, Davtian L, Darji D, Demidova A, Diaz J, Dunning J, Duque-Vallejo S, Edinburgh T, Garcia-Gallo E, Hashmi M, Hassan Z, Ho A, Horby P, Jackson C, Judd C, Kelly S, Kiseleva A, Lim WS, Lunn M, Mello C, Merson L, Murthy S, de Oliveira VSB, Olliaro P, Pesonel E, Le Prevost M, Reyes LF, Rojek A, Rylance J, Sauer L, Sconza R, Semple C, Sharin L, Siddiqui A, Uyeki T, Watson H, Wu J. ISARIC ARC (v1.5.0). *ISARIC* \|year\|. <doi:%6010.5281/zenodo.14162844> \<https://doi.org/10.5281/zenodo.14162844\>\`\_
+> Bourner J, Carson G, Chang A, Chernyavskaya A, Cummings M, Davtian L, Darji D, Demidova A, Diaz J, Dunning J, Duque-Vallejo S, Edinburgh T, Garcia-Gallo E, Hashmi M, Hassan Z, Ho A, Horby P, Jackson C, Judd C, Kelly S, Kiseleva A, Lim WS, Lunn M, Mello C, Merson L, Murthy S, de Oliveira VSB, Olliaro P, Pesonel E, Le Prevost M, Reyes LF, Rojek A, Rylance J, Sauer L, Sconza R, Semple C, Sharin L, Siddiqui A, Uyeki T, Watson H, Wu J. ISARIC ARC (v1.5.0). *ISARIC* 2026. [doi:10.5281/zenodo.14162844](https://doi.org/10.5281/zenodo.14162844)
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,17 @@ If you want to use ARC for your research or study, follow these steps:
 
 Key aspects of ARC, including the core schema, and response option lists, are also documented in HTML [here](https://isaric-arc.readthedocs.io/en/latest/index.html).
 
+
+## Citing ARC
+
+ARC is **published** on [GitHub](https://github.com/ISARICResearch/ARC/releases) and [Zenodo](https://zenodo.org/records/21337201). It has the DOI:
+
+[10.5281/zenodo.14162844](https://doi.org/10.5281/zenodo.14162844)
+
+ARC can be **cited** as follows:
+
+> Bourner J, Carson G, Chang A, Chernyavskaya A, Cummings M, Davtian L, Darji D, Demidova A, Diaz J, Dunning J, Duque-Vallejo S, Edinburgh T, Garcia-Gallo E, Hashmi M, Hassan Z, Ho A, Horby P, Jackson C, Judd C, Kelly S, Kiseleva A, Lim WS, Lunn M, Mello C, Merson L, Murthy S, de Oliveira VSB, Olliaro P, Pesonel E, Le Prevost M, Reyes LF, Rojek A, Rylance J, Sauer L, Sconza R, Semple C, Sharin L, Siddiqui A, Uyeki T, Watson H, Wu J. ISARIC ARC (v1.5.0). *ISARIC* \|year\|. <doi:%6010.5281/zenodo.14162844> \<https://doi.org/10.5281/zenodo.14162844\>\`\_
+
 ## Contributors
 
 ### Conceptualization

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,8 @@ from datetime import datetime
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 author = "ISARIC"
-copyright = f"ISARIC, {datetime.now().year}"
+year = datetime.now().year
+copyright = f"ISARIC, {year}"
 description = """ARC (Acute and Rapid onset disease Case report form) - standardised clinical data collection."""
 github_url = "https://github.com"
 github_repo = f"{github_url}/ISARICResearch/ARC"
@@ -52,9 +53,13 @@ language = "en"
 # Set primary domain to null
 primary_domain = None
 
-# Global substitutions - not required for the moment
+# Global substitutions - can be used in RST pages with the syntax
+#
+#     |label|
+#
 rst_epilog = f"""
 .. |author|                 replace:: **{author}**
+.. |year|                   replace:: **{year}**
 .. |copyright|              replace:: **{copyright}**
 .. |docs_url|               replace:: ''
 .. |project|                replace:: **{project}**

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,8 @@ ARC is designed to serve as a resource for researchers and healthcare profession
 
 - **ISARIC Data Schema**: ARC forms the basis of the standardized :doc:`ISARIC data schema <sources/isaric-data-schema>` used across the ISARIC ecosystem, including DataHub. Data collected via BRIDGE-generated CRFs and REDCap can be automatically converted into this schema using auto-generated parsers; data from other sources can be converted using `ADTL <https://adtl.readthedocs.io/en/latest/index.html>`_ with a :doc:`custom parser <sources/writing-a-parser>`.
 
+- **Citable**: Refer :ref:`here <citing-arc>` for more details.
+
 ARC is licensed under the `Open Source Initiative (OSI) <https://opensource.org>`_-compliant `MIT license <https://opensource.org/license/mit>`_.
 
 .. image:: _static/osi-badge-light.svg

--- a/docs/sources/using-arc.rst
+++ b/docs/sources/using-arc.rst
@@ -12,3 +12,16 @@ You can use ARC for research or study in different ways:
 - Converting data to the ISARIC schema: ARC defines the standardized :ref:`ISARIC data schema <isaric-data-schema>` used across the ISARIC ecosystem. If your data was collected via BRIDGE / REDCap, a parser can be auto-generated using ``schemas/draft_parser.py``. For data collected with other tools, you can write a custom parser using `ADTL <https://adtl.readthedocs.io/en/latest/index.html>`_ — see :ref:`writing-a-parser` for a worked example.
 
 - Contributions: While contributions to the ARC schema and related documents are limited to authorized users, you can create GitHub `issues <https://github.com/ISARICResearch/ARC/issues>`_ or `discussions <https://github.com/ISARICResearch/ARC/discussions>`_ for raising questions, suggestions, or clarifications.
+
+.. _citing-arc:
+
+Citing ARC
+----------
+
+ARC is **published** on `GitHub <https://github.com/ISARICResearch/ARC/releases>`_ and `Zenodo <https://zenodo.org/records/21337201>`_. It has the DOI:
+
+`10.5281/zenodo.14162844 <https://doi.org/10.5281/zenodo.14162844>`_
+
+ARC can be **cited** as follows:
+
+	Bourner J, Carson G, Chang A, Chernyavskaya A, Cummings M, Davtian L, Darji D, Demidova A, Diaz J, Dunning J,  Duque-Vallejo S, Edinburgh T, Garcia-Gallo E, Hashmi M, Hassan Z, Ho A, Horby P, Jackson C, Judd C, Kelly S,  Kiseleva A, Lim WS, Lunn M, Mello C, Merson L, Murthy S, de Oliveira VSB, Olliaro P, Pesonel E, Le Prevost M, Reyes LF, Rojek A, Rylance J, Sauer L, Sconza R, Semple C, Sharin L, Siddiqui A, Uyeki T, Watson H, Wu J. ISARIC ARC (v1.5.0). *ISARIC* |year|. doi:`10.5281/zenodo.14162844 <https://doi.org/10.5281/zenodo.14162844>`_


### PR DESCRIPTION
- Link Zenodo DOI into the citation file (`CITATION.cff`), and improve indentation and formatting.
- Adds citation instructions to the Sphinx docs (in Using Arc) and the README.

This is the [Sphinx version](https://isaric-arc.readthedocs.io/en/latest/sources/using-arc.html#citing-arc) of the citation page.