### PR TITLE
Temporarily disable the failing medium/low priority unit tests

### DIFF
--- a/.github/workflows/test-medium-low.yml
+++ b/.github/workflows/test-medium-low.yml
@@ -1,10 +1,6 @@
 name: Run tests marked as medium or low
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR updates the medium/low priority test workflow to run only via workflow_dispatch.